### PR TITLE
Add buys wait loop

### DIFF
--- a/platform/ext/target/cypress/psoc64/mailbox/platform_ns_mailbox.c
+++ b/platform/ext/target/cypress/psoc64/mailbox/platform_ns_mailbox.c
@@ -177,6 +177,10 @@ static cy_en_ipcsema_status_t mailbox_raw_spin_lock(uint32_t ipc_channel,
                  * notification event from secure core. However, it is more
                  * complex and requires more code and more modifications.
                  */
+                volatile uint32_t count = 1000;
+                while(count > 0) {
+                    count--;
+                }
                 Cy_IPC_Sema_Status(sema_num);
             }
         }


### PR DESCRIPTION
In CM4, while trying to acquire mailbox semaphore lock, it might be
possible that secure core (CM0) is already occupying that lock. Therefore we need to
insert a small delay to give the secure core a chance to acquire the IPC
channel and release the lock.
Otherwise, the secure core may not be able to release the lock if non-secure
core has higher CPU frequency. Thus generating a deadlock.
This delay won't harm performance too much since non-secure
core has to busy wait here anyway.

Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>