### PR TITLE
Removed unused header

### DIFF
--- a/interface/src/tfm_crypto_ipc_api.c
+++ b/interface/src/tfm_crypto_ipc_api.c
@@ -5,7 +5,6 @@
  *
  */
 
-#include "tfm_veneers.h"
 #include "tfm_crypto_defs.h"
 #include "psa/crypto.h"
 #include "tfm_ns_interface.h"

--- a/interface/src/tfm_initial_attestation_ipc_api.c
+++ b/interface/src/tfm_initial_attestation_ipc_api.c
@@ -6,7 +6,6 @@
  */
 
 #include "psa/initial_attestation.h"
-#include "tfm_veneers.h"
 #include "tfm_ns_interface.h"
 #include "psa/client.h"
 #include "psa/crypto_types.h"

--- a/interface/src/tfm_sst_ipc_api.c
+++ b/interface/src/tfm_sst_ipc_api.c
@@ -8,7 +8,6 @@
 #include "psa/protected_storage.h"
 
 #include "tfm_ns_interface.h"
-#include "tfm_veneers.h"
 #include "psa_manifest/sid.h"
 
 #define IOVEC_LEN(x) (uint32_t)(sizeof(x)/sizeof(x[0]))


### PR DESCRIPTION
Remove the header `tfm_veneers.h` from PSA IPC API source files.

TF-M reference: https://developer.trustedfirmware.org/T684

Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>