### PR TITLE
Declare the enrollment algorithm for a key

### DIFF
--- a/interface/include/psa/crypto_extra.h
+++ b/interface/include/psa/crypto_extra.h
@@ -24,6 +24,32 @@
 extern "C" {
 #endif
 
+/** \brief Declare the enrollment algorithm for a key.
+ *
+ * An operation on a key may indifferently use the algorithm set with
+ * psa_set_key_algorithm() or with this function.
+ *
+ * \param[out] attributes       The attribute structure to write to.
+ * \param alg2                  A second algorithm that the key may be used
+ *                              for, in addition to the algorithm set with
+ *                              psa_set_key_algorithm().
+ *
+ * \warning Setting an enrollment algorithm is not recommended, because
+ *          using the same key with different algorithms can allow some
+ *          attacks based on arithmetic relations between different
+ *          computations made with the same key, or can escalate harmless
+ *          side channels into exploitable ones. Use this function only
+ *          if it is necessary to support a protocol for which it has been
+ *          verified that the usage of the key with multiple algorithms
+ *          is safe.
+ */
+static inline void psa_set_key_enrollment_algorithm(
+    psa_key_attributes_t *attributes,
+    psa_algorithm_t alg2)
+{
+    attributes->core.policy.alg2 = alg2;
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
An operation on a key may indifferently use the algorithm set with
psa_set_key_algorithm() or with this function.

Warning:
Setting an enrollment algorithm is not recommended, because
using the same key with different algorithms can allow some
attacks based on arithmetic relations between different
computations made with the same key, or can escalate harmless
side channels into exploitable ones. Use this function only
if it is necessary to support a protocol for which it has been
verified that the usage of the key with multiple algorithms
is safe.

Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>