### PR TITLE
DO NOT MERGE: psa: Add `mbedtls_ecc_group_to_psa`

### DIFF
--- a/interface/include/psa/crypto_extra.h
+++ b/interface/include/psa/crypto_extra.h
@@ -50,6 +50,68 @@ static inline void psa_set_key_enrollment_algorithm(
     attributes->core.policy.alg2 = alg2;
 }
 
+/** Convert an ECC curve identifier from the Mbed TLS encoding to PSA.
+ *
+ * \note This function is provided solely for the convenience of
+ *       Mbed TLS and may be removed at any time without notice.
+ *
+ * \param grpid         An Mbed TLS elliptic curve identifier
+ *                      (`MBEDTLS_ECP_DP_xxx`).
+ * \param[out] bits     On success, the bit size of the curve.
+ *
+ * \return              The corresponding PSA elliptic curve identifier
+ *                      (`PSA_ECC_CURVE_xxx`).
+ * \return              \c 0 on failure (\p grpid is not recognized).
+ */
+static inline psa_ecc_curve_t mbedtls_ecc_group_to_psa( mbedtls_ecp_group_id grpid,
+                                                        size_t *bits )
+{
+    switch( grpid )
+    {
+        case MBEDTLS_ECP_DP_SECP192R1:
+            *bits = 192;
+            return( PSA_ECC_CURVE_SECP_R1 );
+        case MBEDTLS_ECP_DP_SECP224R1:
+            *bits = 224;
+            return( PSA_ECC_CURVE_SECP_R1 );
+        case MBEDTLS_ECP_DP_SECP256R1:
+            *bits = 256;
+            return( PSA_ECC_CURVE_SECP_R1 );
+        case MBEDTLS_ECP_DP_SECP384R1:
+            *bits = 384;
+            return( PSA_ECC_CURVE_SECP_R1 );
+        case MBEDTLS_ECP_DP_SECP521R1:
+            *bits = 521;
+            return( PSA_ECC_CURVE_SECP_R1 );
+        case MBEDTLS_ECP_DP_BP256R1:
+            *bits = 256;
+            return( PSA_ECC_CURVE_BRAINPOOL_P_R1 );
+        case MBEDTLS_ECP_DP_BP384R1:
+            *bits = 384;
+            return( PSA_ECC_CURVE_BRAINPOOL_P_R1 );
+        case MBEDTLS_ECP_DP_BP512R1:
+            *bits = 512;
+            return( PSA_ECC_CURVE_BRAINPOOL_P_R1 );
+        case MBEDTLS_ECP_DP_CURVE25519:
+            *bits = 255;
+            return( PSA_ECC_CURVE_MONTGOMERY );
+        case MBEDTLS_ECP_DP_SECP192K1:
+            *bits = 192;
+            return( PSA_ECC_CURVE_SECP_K1 );
+        case MBEDTLS_ECP_DP_SECP224K1:
+            *bits = 224;
+            return( PSA_ECC_CURVE_SECP_K1 );
+        case MBEDTLS_ECP_DP_SECP256K1:
+            *bits = 256;
+            return( PSA_ECC_CURVE_SECP_K1 );
+        case MBEDTLS_ECP_DP_CURVE448:
+            *bits = 448;
+            return( PSA_ECC_CURVE_MONTGOMERY );
+        default:
+            return( 0 );
+    }
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Convert an ECC curve identifier from the Mbed TLS encoding to PSA.

This function is provided solely for the convenience of Mbed TLS and
may be removed at any time without notice.

Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>