### PR TITLE
test: Fix plat_test.c

### DIFF
--- a/platform/ext/target/musca_a/plat_test.c
+++ b/platform/ext/target/musca_a/plat_test.c
@@ -62,7 +62,7 @@ uint32_t tfm_plat_test_get_userled_mask(void)
     return USERLED_MASK;
 }
 
-
+#if DOMAIN_NS == 0
 void tfm_plat_test_secure_timer_start(void)
 {
     if (!timer_cmsdk_is_initialized(&CMSDK_TIMER0_DEV_S)) {
@@ -80,6 +80,8 @@ void tfm_plat_test_secure_timer_stop(void)
     timer_cmsdk_clear_interrupt(&CMSDK_TIMER0_DEV_S);
 }
 
+#else
+
 void tfm_plat_test_non_secure_timer_start(void)
 {
     if (!timer_cmsdk_is_initialized(&CMSDK_TIMER1_DEV_NS)) {
@@ -96,3 +98,4 @@ void tfm_plat_test_non_secure_timer_stop(void)
     timer_cmsdk_disable_interrupt(&CMSDK_TIMER1_DEV_NS);
     timer_cmsdk_clear_interrupt(&CMSDK_TIMER1_DEV_NS);
 }
+#endif /* DOMAIN_NS == 0 */


### PR DESCRIPTION
The timer structure `CMSDK_TIMER0_DEV_S` is only defined for secure
side, however it is used unconditionally in plat_test.c. When compiling
with Arm compiler 6.13, the symbol CMSDK_TIMER0_DEV_S gets into
`libtfm_non_secure_tests.a` which is used by non-secure side. Building
non-secure side with `libtfm_non_secure_tests.a` results in
linker error for missing symbol `CMSDK_TIMER0_DEV_S`.
Use the macro `DOMAIN_NS` to identify secure and non-secure side code.

Response from Arm compiler team about using `--remove`:

Elimination of unused sections (e.g. functions) is an optimisation.
The linker will still report an undefined symbol error if symbols are
missing, i.e. the correctness of the program should not depend on
an optional linker optimisation.

https://developer.trustedfirmware.org/T767

Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>