### PR TITLE
Import old patches from `mbed-tfm-1.1` for TF-M v1.2 + Mbed OS integration

### DIFF
--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -18,6 +18,9 @@ if (TFM_MULTI_CORE_TOPOLOGY)
     add_library(platform_ns STATIC)
 endif()
 
+#CMSIS
+include_directories(${TFM_TEST_REPO_PATH}/CMSIS/RTOS2/Include)
+
 ###################### PSA interface (header only) #############################
 
 add_library(psa_interface INTERFACE)

--- a/interface/include/tfm_multi_core_api.h
+++ b/interface/include/tfm_multi_core_api.h
@@ -40,8 +40,8 @@ int32_t tfm_platform_ns_wait_for_s_cpu_ready(void);
  * \brief Acquire the multi-core lock for synchronizing PSA client call(s)
  *        The actual implementation depends on the use scenario.
  *
- * \return \ref OS_WRAPPER_SUCCESS on success
- * \return \ref OS_WRAPPER_ERROR on error
+ * \return \ref TFM_SUCCESS on success
+ * \return \ref TFM_ERROR_GENERIC on error
  */
 uint32_t tfm_ns_multi_core_lock_acquire(void);
 
@@ -49,8 +49,8 @@ uint32_t tfm_ns_multi_core_lock_acquire(void);
  * \brief Release the multi-core lock for synchronizing PSA client call(s)
  *        The actual implementation depends on the use scenario.
  *
- * \return \ref OS_WRAPPER_SUCCESS on success
- * \return \ref OS_WRAPPER_ERROR on error
+ * \return \ref TFM_SUCCESS on success
+ * \return \ref TFM_ERROR_GENERIC on error
  */
 uint32_t tfm_ns_multi_core_lock_release(void);
 

--- a/interface/include/tfm_ns_mailbox.h
+++ b/interface/include/tfm_ns_mailbox.h
@@ -84,7 +84,6 @@ bool tfm_ns_mailbox_is_msg_replied(mailbox_msg_handle_t handle);
  */
 int32_t tfm_ns_mailbox_init(struct ns_mailbox_queue_t *queue);
 
-#ifdef TFM_MULTI_CORE_MULTI_CLIENT_CALL
 /**
  * \brief Get the handle of the current non-secure task executing mailbox
  *        functionalities
@@ -97,12 +96,6 @@ int32_t tfm_ns_mailbox_init(struct ns_mailbox_queue_t *queue);
  * \return Return the handle of task.
  */
 const void *tfm_ns_mailbox_get_task_handle(void);
-#else
-static inline const void *tfm_ns_mailbox_get_task_handle(void)
-{
-    return NULL;
-}
-#endif
 
 /**
  * \brief Fetch the handle to the first replied mailbox message in the NSPE

--- a/interface/src/tfm_multi_core_api.c
+++ b/interface/src/tfm_multi_core_api.c
@@ -5,22 +5,23 @@
  *
  */
 
-#include "os_wrapper/semaphore.h"
-
 #include "tfm_api.h"
 #include "tfm_mailbox.h"
 #include "tfm_multi_core_api.h"
+#include "cmsis_os2.h"
 
 #define MAX_SEMAPHORE_COUNT            NUM_MAILBOX_QUEUE_SLOT
 
-static void *ns_lock_handle = NULL;
+static osSemaphoreId_t ns_lock_handle = NULL;
 
 __attribute__((weak))
 enum tfm_status_e tfm_ns_interface_init(void)
 {
-    ns_lock_handle = os_wrapper_semaphore_create(MAX_SEMAPHORE_COUNT,
-                                                 MAX_SEMAPHORE_COUNT,
-                                                 NULL);
+    osSemaphoreAttr_t sema_attrib = {0};
+
+    ns_lock_handle = osSemaphoreNew(MAX_SEMAPHORE_COUNT,
+                                    MAX_SEMAPHORE_COUNT,
+                                    &sema_attrib);
     if (!ns_lock_handle) {
         return TFM_ERROR_GENERIC;
     }
@@ -35,11 +36,10 @@ int32_t tfm_ns_wait_for_s_cpu_ready(void)
 
 uint32_t tfm_ns_multi_core_lock_acquire(void)
 {
-    return os_wrapper_semaphore_acquire(ns_lock_handle,
-                                        OS_WRAPPER_WAIT_FOREVER);
+    return osSemaphoreAcquire(ns_lock_handle, osWaitForever);
 }
 
 uint32_t tfm_ns_multi_core_lock_release(void)
 {
-    return os_wrapper_semaphore_release(ns_lock_handle);
+    return osSemaphoreRelease(ns_lock_handle);
 }

--- a/interface/src/tfm_multi_core_psa_ns_api.c
+++ b/interface/src/tfm_multi_core_psa_ns_api.c
@@ -8,8 +8,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include "os_wrapper/mutex.h"
-
 #include "psa/client.h"
 #include "psa/error.h"
 #include "tfm_api.h"
@@ -64,7 +62,7 @@ uint32_t psa_framework_version(void)
     uint32_t version;
     int32_t ret;
 
-    if (tfm_ns_multi_core_lock_acquire() != OS_WRAPPER_SUCCESS) {
+    if (tfm_ns_multi_core_lock_acquire() != TFM_SUCCESS) {
         return PSA_VERSION_NONE;
     }
 
@@ -82,7 +80,7 @@ uint32_t psa_framework_version(void)
         version = PSA_VERSION_NONE;
     }
 
-    if (tfm_ns_multi_core_lock_release() != OS_WRAPPER_SUCCESS) {
+    if (tfm_ns_multi_core_lock_release() != TFM_SUCCESS) {
         return PSA_VERSION_NONE;
     }
 
@@ -98,7 +96,7 @@ uint32_t psa_version(uint32_t sid)
 
     params.psa_version_params.sid = sid;
 
-    if (tfm_ns_multi_core_lock_acquire() != OS_WRAPPER_SUCCESS) {
+    if (tfm_ns_multi_core_lock_acquire() != TFM_SUCCESS) {
         return PSA_VERSION_NONE;
     }
 
@@ -116,7 +114,7 @@ uint32_t psa_version(uint32_t sid)
         version = PSA_VERSION_NONE;
     }
 
-    if (tfm_ns_multi_core_lock_release() != OS_WRAPPER_SUCCESS) {
+    if (tfm_ns_multi_core_lock_release() != TFM_SUCCESS) {
         return PSA_VERSION_NONE;
     }
 
@@ -133,7 +131,7 @@ psa_handle_t psa_connect(uint32_t sid, uint32_t version)
     params.psa_connect_params.sid = sid;
     params.psa_connect_params.version = version;
 
-    if (tfm_ns_multi_core_lock_acquire() != OS_WRAPPER_SUCCESS) {
+    if (tfm_ns_multi_core_lock_acquire() != TFM_SUCCESS) {
         return PSA_NULL_HANDLE;
     }
 
@@ -151,7 +149,7 @@ psa_handle_t psa_connect(uint32_t sid, uint32_t version)
         psa_handle = PSA_NULL_HANDLE;
     }
 
-    if (tfm_ns_multi_core_lock_release() != OS_WRAPPER_SUCCESS) {
+    if (tfm_ns_multi_core_lock_release() != TFM_SUCCESS) {
         return PSA_NULL_HANDLE;
     }
 
@@ -174,7 +172,7 @@ psa_status_t psa_call(psa_handle_t handle, int32_t type,
     params.psa_call_params.out_vec = out_vec;
     params.psa_call_params.out_len = out_len;
 
-    if (tfm_ns_multi_core_lock_acquire() != OS_WRAPPER_SUCCESS) {
+    if (tfm_ns_multi_core_lock_acquire() != TFM_SUCCESS) {
         return PSA_ERROR_GENERIC_ERROR;
     }
 
@@ -192,7 +190,7 @@ psa_status_t psa_call(psa_handle_t handle, int32_t type,
         status = PSA_INTER_CORE_COMM_ERR;
     }
 
-    if (tfm_ns_multi_core_lock_release() != OS_WRAPPER_SUCCESS) {
+    if (tfm_ns_multi_core_lock_release() != TFM_SUCCESS) {
         return PSA_ERROR_GENERIC_ERROR;
     }
 
@@ -207,7 +205,7 @@ void psa_close(psa_handle_t handle)
 
     params.psa_close_params.handle = handle;
 
-    if (tfm_ns_multi_core_lock_acquire() != OS_WRAPPER_SUCCESS) {
+    if (tfm_ns_multi_core_lock_acquire() != TFM_SUCCESS) {
         return;
     }
 

--- a/interface/src/tfm_ns_interface.c
+++ b/interface/src/tfm_ns_interface.c
@@ -7,15 +7,14 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include "os_wrapper/mutex.h"
-
 #include "tfm_api.h"
 #include "tfm_ns_interface.h"
+#include "cmsis_os2.h"
 
 /**
  * \brief the ns_lock ID
  */
-static void *ns_lock_handle = NULL;
+static osMutexId_t ns_lock_handle = NULL;
 
 __attribute__((weak))
 int32_t tfm_ns_interface_dispatch(veneer_fn fn,
@@ -23,16 +22,18 @@ int32_t tfm_ns_interface_dispatch(veneer_fn fn,
                                   uint32_t arg2, uint32_t arg3)
 {
     int32_t result;
+    osStatus_t status;
 
     /* TFM request protected by NS lock */
-    if (os_wrapper_mutex_acquire(ns_lock_handle, OS_WRAPPER_WAIT_FOREVER)
-            != OS_WRAPPER_SUCCESS) {
+    status = osMutexAcquire(ns_lock_handle, osWaitForever);
+    if (status != osOK) {
         return (int32_t)TFM_ERROR_GENERIC;
     }
 
     result = fn(arg0, arg1, arg2, arg3);
 
-    if (os_wrapper_mutex_release(ns_lock_handle) != OS_WRAPPER_SUCCESS) {
+    status = osMutexRelease(ns_lock_handle);
+    if (status != osOK) {
         return (int32_t)TFM_ERROR_GENERIC;
     }
 
@@ -42,13 +43,22 @@ int32_t tfm_ns_interface_dispatch(veneer_fn fn,
 __attribute__((weak))
 enum tfm_status_e tfm_ns_interface_init(void)
 {
-    void *handle;
+    const osMutexAttr_t attr = {
+        .name = NULL,
+        .attr_bits = osMutexPrioInherit, /* Priority inheritance is recommended
+                                          * to enable if it is supported.
+                                          * For recursive mutex and the ability
+                                          * of auto release when owner being
+                                          * terminated is not required.
+                                          */
+        .cb_mem = NULL,
+        .cb_size = 0U
+    };
 
-    handle = os_wrapper_mutex_create();
-    if (!handle) {
+    ns_lock_handle = osMutexNew(&attr);
+    if (!ns_lock_handle) {
         return TFM_ERROR_GENERIC;
     }
 
-    ns_lock_handle = handle;
     return TFM_SUCCESS;
 }

--- a/platform/ext/target/cypress/psoc64/Device/Config/device_cfg.h
+++ b/platform/ext/target/cypress/psoc64/Device/Config/device_cfg.h
@@ -2,6 +2,8 @@
  * Copyright (c) 2017-2018 Arm Limited
  * Copyright (c) 2020, Cypress Semiconductor Corporation. All rights reserved.
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed under the Apache License Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/platform/ext/target/cypress/psoc64/mailbox/platform_ns_mailbox.c
+++ b/platform/ext/target/cypress/psoc64/mailbox/platform_ns_mailbox.c
@@ -100,7 +100,11 @@ int32_t tfm_ns_mailbox_hal_init(struct ns_mailbox_queue_t *queue)
 
 const void *tfm_ns_mailbox_get_task_handle(void)
 {
+#ifdef TFM_MULTI_CORE_MULTI_CLIENT_CALL
     return os_wrapper_thread_get_handle();
+#else
+    return NULL;
+#endif
 }
 
 void tfm_ns_mailbox_hal_wait_reply(mailbox_msg_handle_t handle)

--- a/platform/ext/target/cypress/psoc64/partition/flash_layout.h
+++ b/platform/ext/target/cypress/psoc64/partition/flash_layout.h
@@ -2,6 +2,8 @@
  * Copyright (c) 2017-2020 Arm Limited. All rights reserved.
  * Copyright (c) 2019-2020, Cypress Semiconductor Corporation. All rights reserved.
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/platform/ext/target/cypress/psoc64/partition/region_defs.h
+++ b/platform/ext/target/cypress/psoc64/partition/region_defs.h
@@ -2,6 +2,8 @@
  * Copyright (c) 2017-2020 ARM Limited. All rights reserved.
  * Copyright (c) 2019-2020, Cypress Semiconductor Corporation. All rights reserved.
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/readme.rst
+++ b/readme.rst
@@ -5,6 +5,13 @@ The Trusted Firmware-M software implementation contained in this project is
 designed to be a reference implementation of the
 `Platform Security Architecture`_ (PSA) for `ARMv7-M and Armv8-M`_.
 
+#################################
+Mbed OS + Trusted Firmware-M v1.2
+#################################
+
+This specific branch supports additional patches required for integration
+of Mbed OS with Trusted Firmware-M v1.2 implementation.
+
 ###########
 Quick Links
 ###########


### PR DESCRIPTION
These patches have been imported from TFM v1.1 to get the integration work going for TFM v1.2

These can be referred here - https://github.com/ARMmbed/trusted-firmware-m/compare/mbed-tfm-1.1 