### PR TITLE
Add missing mbedtls_ecc_group_to_psa()

### DIFF
--- a/interface/include/psa/crypto_extra.h
+++ b/interface/include/psa/crypto_extra.h
@@ -57,6 +57,74 @@ extern "C" {
 
 /**@}*/
 
+#if defined(MBEDTLS_ECP_C)
+#include <mbedtls/ecp.h>
+
+/** Convert an ECC curve identifier from the Mbed TLS encoding to PSA.
+ *
+ * \note This function is provided solely for the convenience of
+ *       Mbed TLS and may be removed at any time without notice.
+ *
+ * \param grpid         An Mbed TLS elliptic curve identifier
+ *                      (`MBEDTLS_ECP_DP_xxx`).
+ * \param[out] bits     On success, the bit size of the curve.
+ *
+ * \return              The corresponding PSA elliptic curve identifier
+ *                      (`PSA_ECC_FAMILY_xxx`).
+ * \return              \c 0 on failure (\p grpid is not recognized).
+ */
+static inline psa_ecc_family_t mbedtls_ecc_group_to_psa( mbedtls_ecp_group_id grpid,
+                                                        size_t *bits )
+{
+    switch( grpid )
+    {
+        case MBEDTLS_ECP_DP_SECP192R1:
+            *bits = 192;
+            return( PSA_ECC_FAMILY_SECP_R1 );
+        case MBEDTLS_ECP_DP_SECP224R1:
+            *bits = 224;
+            return( PSA_ECC_FAMILY_SECP_R1 );
+        case MBEDTLS_ECP_DP_SECP256R1:
+            *bits = 256;
+            return( PSA_ECC_FAMILY_SECP_R1 );
+        case MBEDTLS_ECP_DP_SECP384R1:
+            *bits = 384;
+            return( PSA_ECC_FAMILY_SECP_R1 );
+        case MBEDTLS_ECP_DP_SECP521R1:
+            *bits = 521;
+            return( PSA_ECC_FAMILY_SECP_R1 );
+        case MBEDTLS_ECP_DP_BP256R1:
+            *bits = 256;
+            return( PSA_ECC_FAMILY_BRAINPOOL_P_R1 );
+        case MBEDTLS_ECP_DP_BP384R1:
+            *bits = 384;
+            return( PSA_ECC_FAMILY_BRAINPOOL_P_R1 );
+        case MBEDTLS_ECP_DP_BP512R1:
+            *bits = 512;
+            return( PSA_ECC_FAMILY_BRAINPOOL_P_R1 );
+        case MBEDTLS_ECP_DP_CURVE25519:
+            *bits = 255;
+            return( PSA_ECC_FAMILY_MONTGOMERY );
+        case MBEDTLS_ECP_DP_SECP192K1:
+            *bits = 192;
+            return( PSA_ECC_FAMILY_SECP_K1 );
+        case MBEDTLS_ECP_DP_SECP224K1:
+            *bits = 224;
+            return( PSA_ECC_FAMILY_SECP_K1 );
+        case MBEDTLS_ECP_DP_SECP256K1:
+            *bits = 256;
+            return( PSA_ECC_FAMILY_SECP_K1 );
+        case MBEDTLS_ECP_DP_CURVE448:
+            *bits = 448;
+            return( PSA_ECC_FAMILY_MONTGOMERY );
+        default:
+            *bits = 0;
+            return( 0 );
+    }
+}
+
+#endif /* MBEDTLS_ECP_C */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Note: Same as https://github.com/ARMmbed/mbed-os/commit/e2e2d0b but should be in this repo, as the process is to copy PSA headers into Mbed OS.

The PSA headers imported from TF-M is not fully up to date with Mbed TLS 2.24.0, and does not contain a declaration of
mbedtls_ecc_group_to_psa(), which is expected by pk.c from Mbed TLS. This makes it impossible to use certain functions from pk.c and generates an "undefined symbol" error. (Also, the Arm toolchain requires symbols to be defined whether it's used or not.)

Note: This change is does not affect TF-M itself which doesn't use pk.c, but an application or OS may need it or be built with the full Mbed TLS.