### PR TITLE
Revert the check on DOMAIN_NS (#10)

### DIFF
--- a/platform/ext/target/musca_b1/plat_test.c
+++ b/platform/ext/target/musca_b1/plat_test.c
@@ -62,8 +62,6 @@ uint32_t tfm_plat_test_get_userled_mask(void)
     return USERLED_MASK;
 }
 
-#if DOMAIN_NS == 0
-
 void tfm_plat_test_secure_timer_start(void)
 {
     if (!timer_cmsdk_is_initialized(&CMSDK_TIMER0_DEV_S)) {
@@ -81,8 +79,6 @@ void tfm_plat_test_secure_timer_stop(void)
     timer_cmsdk_clear_interrupt(&CMSDK_TIMER0_DEV_S);
 }
 
-#else /* DOMAIN_NS == 0 */
-
 void tfm_plat_test_non_secure_timer_start(void)
 {
     if (!timer_cmsdk_is_initialized(&CMSDK_TIMER1_DEV_NS)) {
@@ -99,5 +95,3 @@ void tfm_plat_test_non_secure_timer_stop(void)
     timer_cmsdk_disable_interrupt(&CMSDK_TIMER1_DEV_NS);
     timer_cmsdk_clear_interrupt(&CMSDK_TIMER1_DEV_NS);
 }
-
-#else /* DOMAIN_NS == 0 */

--- a/platform/ext/target/musca_s1/plat_test.c
+++ b/platform/ext/target/musca_s1/plat_test.c
@@ -62,8 +62,6 @@ uint32_t tfm_plat_test_get_userled_mask(void)
     return USERLED_MASK;
 }
 
-#if DOMAIN_NS == 0
-
 void tfm_plat_test_secure_timer_start(void)
 {
     if (!timer_cmsdk_is_initialized(&CMSDK_TIMER0_DEV_S)) {
@@ -81,8 +79,6 @@ void tfm_plat_test_secure_timer_stop(void)
     timer_cmsdk_clear_interrupt(&CMSDK_TIMER0_DEV_S);
 }
 
-#else /* DOMAIN_NS == 0 */
-
 void tfm_plat_test_non_secure_timer_start(void)
 {
     if (!timer_cmsdk_is_initialized(&CMSDK_TIMER1_DEV_NS)) {
@@ -99,5 +95,3 @@ void tfm_plat_test_non_secure_timer_stop(void)
     timer_cmsdk_disable_interrupt(&CMSDK_TIMER1_DEV_NS);
     timer_cmsdk_clear_interrupt(&CMSDK_TIMER1_DEV_NS);
 }
-
-#endif /* DOMAIN_NS == 0 */


### PR DESCRIPTION
In #10 we check the macro `DOMAIN_NS` in order to enable secure/non-secure timer functions in `plat_test.c` conditionally, but the macro definition has been removed from TF-M v1.2's build system.

This is okay for now, because the workaround https://github.com/ARMmbed/mbed-os-tf-m-regression-tests/pull/60/commits/9d60aa5846c775b3a79e09172c204c943248d4e4 is still in place.