### PR TITLE
Declare `__stdout` as a weak symbol

### DIFF
--- a/platform/ext/common/uart_stdout.c
+++ b/platform/ext/common/uart_stdout.c
@@ -52,7 +52,7 @@ int stdio_output_string(const unsigned char *str, uint32_t len)
 /* Struct FILE is implemented in stdio.h. Used to redirect printf to
  * STDIO_DRIVER
  */
-FILE __stdout;
+__attribute__((weak)) FILE __stdout;
 /* __ARMCC_VERSION is only defined starting from Arm compiler version 6 */
 int fputc(int ch, FILE *f)
 {


### PR DESCRIPTION
TF-M redirects output to serial by declaring its own `FILE __stdout` and `int fputc(int ch, FILE *f)` and disables Arm toolchain's default versions of the two symbols using the flag `-nostdlib`. But if an application or OS (e.g. Mbed OS) needs to link TF-M's platform library while still using the Arm toolchain's standard libraries, linking will fail:

```
  Error: L6200E: Symbol __stdout multiply defined
```
(Note: one copy of `__stdout` from libplatform_ns.ar(uart_stdout.o)`, one from the standard library.)

To address this, turn `__stdout` into be a weak symbol.