### PR TITLE
Deprecated: allow key enrollment algorithms

### DIFF
--- a/interface/include/psa/crypto_client_struct.h
+++ b/interface/include/psa/crypto_client_struct.h
@@ -34,12 +34,13 @@ struct psa_client_key_attributes_s
     uint32_t lifetime;
     uint32_t id;
     uint32_t alg;
+    uint32_t alg2;
     uint32_t usage;
     size_t bits;
     uint16_t type;
 };
 
-#define PSA_CLIENT_KEY_ATTRIBUTES_INIT {0, 0, 0, 0, 0, 0}
+#define PSA_CLIENT_KEY_ATTRIBUTES_INIT {0, 0, 0, 0, 0, 0, 0}
 
 #ifdef __cplusplus
 }

--- a/interface/include/psa/crypto_extra.h
+++ b/interface/include/psa/crypto_extra.h
@@ -125,6 +125,48 @@ static inline psa_ecc_family_t mbedtls_ecc_group_to_psa( mbedtls_ecp_group_id gr
 
 #endif /* MBEDTLS_ECP_C */
 
+/** \brief Declare the enrollment algorithm for a key.
+ *
+ * An operation on a key may indifferently use the algorithm set with
+ * psa_set_key_algorithm() or with this function.
+ *
+ * \param[out] attributes       The attribute structure to write to.
+ * \param alg2                  A second algorithm that the key may be used
+ *                              for, in addition to the algorithm set with
+ *                              psa_set_key_algorithm().
+ *
+ * \deprecated  This is for backward compatibility only.
+ *              Setting an enrollment algorithm is not recommended, because
+ *              using the same key with different algorithms can allow some
+ *              attacks based on arithmetic relations between different
+ *              computations made with the same key, or can escalate harmless
+ *              side channels into exploitable ones. Use this function only
+ *              if it is necessary to support a protocol for which it has been
+ *              verified that the usage of the key with multiple algorithms
+ *              is safe.
+ */
+static inline void psa_set_key_enrollment_algorithm(
+    psa_key_attributes_t *attributes,
+    psa_algorithm_t alg2)
+{
+    attributes->alg2 = alg2;
+}
+
+/** Retrieve the enrollment algorithm policy from key attributes.
+ *
+ * \param[in] attributes        The key attribute structure to query.
+ *
+ * \return The enrollment algorithm stored in the attribute structure.
+
+ * \deprecated  This is for backward compatibility only.
+ *              Deprecated along with psa_set_key_enrollment_algorithm().
+ */
+static inline psa_algorithm_t psa_get_key_enrollment_algorithm(
+    const psa_key_attributes_t *attributes)
+{
+    return attributes->alg2;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/interface/include/tfm_crypto_defs.h
+++ b/interface/include/tfm_crypto_defs.h
@@ -40,6 +40,7 @@ struct tfm_crypto_pack_iovec {
     uint16_t step;               /*!< Key derivation step */
     psa_key_handle_t key_handle; /*!< Key handle */
     psa_algorithm_t alg;         /*!< Algorithm */
+    psa_algorithm_t alg2;        /*!< Enrollment Algorithm */
     uint32_t op_handle;          /*!< Frontend context handle associated to a
                                   *   multipart operation
                                   */

--- a/secure_fw/partitions/crypto/crypto_key.c
+++ b/secure_fw/partitions/crypto/crypto_key.c
@@ -50,6 +50,7 @@ psa_status_t tfm_crypto_key_attributes_from_client(
     key_attributes->core.lifetime = client_key_attr->lifetime;
     key_attributes->core.policy.usage = client_key_attr->usage;
     key_attributes->core.policy.alg = client_key_attr->alg;
+    key_attributes->core.policy.alg2 = client_key_attr->alg2;
     key_attributes->core.bits = client_key_attr->bits;
 
     /* Use the client key id as the key_id and its partition id as the owner */
@@ -75,6 +76,7 @@ psa_status_t tfm_crypto_key_attributes_to_client(
     client_key_attr->lifetime = key_attributes->core.lifetime;
     client_key_attr->usage = key_attributes->core.policy.usage;
     client_key_attr->alg = key_attributes->core.policy.alg;
+    client_key_attr->alg2 = key_attributes->core.policy.alg2;
     client_key_attr->bits = key_attributes->core.bits;
 
     /* Return the key_id as the client key id, do not return the owner */


### PR DESCRIPTION
An operation on a key may indifferently use the algorithm set with `psa_set_key_algorithm()` or with this function.

Warning:
This is DEPRECATED and for backward compatibility only.
Setting an enrollment algorithm is not recommended, because using the
same key with different algorithms can allow some attacks based on
arithmetic relations between different computations made with the same
key, or can escalate harmless side channels into exploitable ones. Use
this function only if it is necessary to support a protocol for which it
has been verified that the usage of the key with multiple algorithms is
safe.

Verified with regression tests on Musca S1 along with https://github.com/ARMmbed/mbed-os/pull/14241 and https://github.com/ARMmbed/tf-m-tests/pull/2