### PR TITLE
Platform: Fix platform init function of Musca S1

### DIFF
--- a/platform/ext/target/musca_s1/target_cfg.c
+++ b/platform/ext/target/musca_s1/target_cfg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Arm Limited. All rights reserved.
+ * Copyright (c) 2018-2021 Arm Limited. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 #include "platform_description.h"
 #include "device_definition.h"
 #include "region_defs.h"
+#include "tfm_hal_platform.h"
 #include "tfm_plat_defs.h"
 #include "region.h"
 #include "cmsis_driver_config.h"
@@ -685,11 +686,14 @@ void ppc_clear_irq(void)
     Driver_APB_PPCEXP1.ClearInterrupt();
 }
 
-enum tfm_plat_err_t tfm_spm_hal_post_init_platform(void)
+enum tfm_hal_status_t tfm_hal_platform_init(void)
 {
     musca_s1_scc_mram_fast_read_enable(&MUSCA_S1_SCC_DEV);
 
     arm_cache_enable_blocking(&SSE_200_CACHE_DEV);
 
-    return TFM_PLAT_ERR_SUCCESS;
+    __enable_irq();
+    stdio_init();
+
+    return TFM_HAL_SUCCESS;
 }


### PR DESCRIPTION
[The commit](https://github.com/ARMmbed/trusted-firmware-m/commit/0eb7c919)

    0eb7c919 HAL: Rename platform init function

combined `tfm_spm_hal_post_init` and `tfm_spm_hal_post_init_platform` into a single weak function `tfm_hal_platform_init` which platforms can override. But Musca S1 was missed out from the refactoring, leading to issues such as IRQ and timers performances.

This commit completes the platform init refactoring for Musca S1 to resolve the issues. The fix is the same as what the original commit did for the other targets.

@evedon Please review.