### PR TITLE
Enable OS wrapper from vanilla TF-M

### DIFF
--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -18,9 +18,6 @@ if (TFM_MULTI_CORE_TOPOLOGY)
     add_library(platform_ns STATIC)
 endif()
 
-#CMSIS
-include_directories(${TFM_TEST_REPO_PATH}/CMSIS/RTOS2/Include)
-
 ###################### PSA interface (header only) #############################
 
 add_library(psa_interface INTERFACE)

--- a/interface/include/tfm_multi_core_api.h
+++ b/interface/include/tfm_multi_core_api.h
@@ -40,8 +40,8 @@ int32_t tfm_platform_ns_wait_for_s_cpu_ready(void);
  * \brief Acquire the multi-core lock for synchronizing PSA client call(s)
  *        The actual implementation depends on the use scenario.
  *
- * \return \ref TFM_SUCCESS on success
- * \return \ref TFM_ERROR_GENERIC on error
+ * \return \ref OS_WRAPPER_SUCCESS on success
+ * \return \ref OS_WRAPPER_ERROR on error
  */
 uint32_t tfm_ns_multi_core_lock_acquire(void);
 
@@ -49,8 +49,8 @@ uint32_t tfm_ns_multi_core_lock_acquire(void);
  * \brief Release the multi-core lock for synchronizing PSA client call(s)
  *        The actual implementation depends on the use scenario.
  *
- * \return \ref TFM_SUCCESS on success
- * \return \ref TFM_ERROR_GENERIC on error
+ * \return \ref OS_WRAPPER_SUCCESS on success
+ * \return \ref OS_WRAPPER_ERROR on error
  */
 uint32_t tfm_ns_multi_core_lock_release(void);
 

--- a/interface/src/tfm_multi_core_api.c
+++ b/interface/src/tfm_multi_core_api.c
@@ -5,23 +5,22 @@
  *
  */
 
+#include "os_wrapper/semaphore.h"
+
 #include "tfm_api.h"
 #include "tfm_mailbox.h"
 #include "tfm_multi_core_api.h"
-#include "cmsis_os2.h"
 
 #define MAX_SEMAPHORE_COUNT            NUM_MAILBOX_QUEUE_SLOT
 
-static osSemaphoreId_t ns_lock_handle = NULL;
+static void *ns_lock_handle = NULL;
 
 __attribute__((weak))
 enum tfm_status_e tfm_ns_interface_init(void)
 {
-    osSemaphoreAttr_t sema_attrib = {0};
-
-    ns_lock_handle = osSemaphoreNew(MAX_SEMAPHORE_COUNT,
-                                    MAX_SEMAPHORE_COUNT,
-                                    &sema_attrib);
+    ns_lock_handle = os_wrapper_semaphore_create(MAX_SEMAPHORE_COUNT,
+                                                 MAX_SEMAPHORE_COUNT,
+                                                 NULL);
     if (!ns_lock_handle) {
         return TFM_ERROR_GENERIC;
     }
@@ -36,10 +35,11 @@ int32_t tfm_ns_wait_for_s_cpu_ready(void)
 
 uint32_t tfm_ns_multi_core_lock_acquire(void)
 {
-    return osSemaphoreAcquire(ns_lock_handle, osWaitForever);
+    return os_wrapper_semaphore_acquire(ns_lock_handle,
+                                        OS_WRAPPER_WAIT_FOREVER);
 }
 
 uint32_t tfm_ns_multi_core_lock_release(void)
 {
-    return osSemaphoreRelease(ns_lock_handle);
+    return os_wrapper_semaphore_release(ns_lock_handle);
 }

--- a/interface/src/tfm_multi_core_psa_ns_api.c
+++ b/interface/src/tfm_multi_core_psa_ns_api.c
@@ -8,6 +8,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "os_wrapper/mutex.h"
+
 #include "psa/client.h"
 #include "psa/error.h"
 #include "tfm_api.h"
@@ -62,7 +64,7 @@ uint32_t psa_framework_version(void)
     uint32_t version;
     int32_t ret;
 
-    if (tfm_ns_multi_core_lock_acquire() != TFM_SUCCESS) {
+    if (tfm_ns_multi_core_lock_acquire() != OS_WRAPPER_SUCCESS) {
         return PSA_VERSION_NONE;
     }
 
@@ -80,7 +82,7 @@ uint32_t psa_framework_version(void)
         version = PSA_VERSION_NONE;
     }
 
-    if (tfm_ns_multi_core_lock_release() != TFM_SUCCESS) {
+    if (tfm_ns_multi_core_lock_release() != OS_WRAPPER_SUCCESS) {
         return PSA_VERSION_NONE;
     }
 
@@ -96,7 +98,7 @@ uint32_t psa_version(uint32_t sid)
 
     params.psa_version_params.sid = sid;
 
-    if (tfm_ns_multi_core_lock_acquire() != TFM_SUCCESS) {
+    if (tfm_ns_multi_core_lock_acquire() != OS_WRAPPER_SUCCESS) {
         return PSA_VERSION_NONE;
     }
 
@@ -114,7 +116,7 @@ uint32_t psa_version(uint32_t sid)
         version = PSA_VERSION_NONE;
     }
 
-    if (tfm_ns_multi_core_lock_release() != TFM_SUCCESS) {
+    if (tfm_ns_multi_core_lock_release() != OS_WRAPPER_SUCCESS) {
         return PSA_VERSION_NONE;
     }
 
@@ -131,7 +133,7 @@ psa_handle_t psa_connect(uint32_t sid, uint32_t version)
     params.psa_connect_params.sid = sid;
     params.psa_connect_params.version = version;
 
-    if (tfm_ns_multi_core_lock_acquire() != TFM_SUCCESS) {
+    if (tfm_ns_multi_core_lock_acquire() != OS_WRAPPER_SUCCESS) {
         return PSA_NULL_HANDLE;
     }
 
@@ -149,7 +151,7 @@ psa_handle_t psa_connect(uint32_t sid, uint32_t version)
         psa_handle = PSA_NULL_HANDLE;
     }
 
-    if (tfm_ns_multi_core_lock_release() != TFM_SUCCESS) {
+    if (tfm_ns_multi_core_lock_release() != OS_WRAPPER_SUCCESS) {
         return PSA_NULL_HANDLE;
     }
 
@@ -172,7 +174,7 @@ psa_status_t psa_call(psa_handle_t handle, int32_t type,
     params.psa_call_params.out_vec = out_vec;
     params.psa_call_params.out_len = out_len;
 
-    if (tfm_ns_multi_core_lock_acquire() != TFM_SUCCESS) {
+    if (tfm_ns_multi_core_lock_acquire() != OS_WRAPPER_SUCCESS) {
         return PSA_ERROR_GENERIC_ERROR;
     }
 
@@ -190,7 +192,7 @@ psa_status_t psa_call(psa_handle_t handle, int32_t type,
         status = PSA_INTER_CORE_COMM_ERR;
     }
 
-    if (tfm_ns_multi_core_lock_release() != TFM_SUCCESS) {
+    if (tfm_ns_multi_core_lock_release() != OS_WRAPPER_SUCCESS) {
         return PSA_ERROR_GENERIC_ERROR;
     }
 
@@ -205,7 +207,7 @@ void psa_close(psa_handle_t handle)
 
     params.psa_close_params.handle = handle;
 
-    if (tfm_ns_multi_core_lock_acquire() != TFM_SUCCESS) {
+    if (tfm_ns_multi_core_lock_acquire() != OS_WRAPPER_SUCCESS) {
         return;
     }
 

--- a/interface/src/tfm_ns_interface.c
+++ b/interface/src/tfm_ns_interface.c
@@ -7,14 +7,15 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "os_wrapper/mutex.h"
+
 #include "tfm_api.h"
 #include "tfm_ns_interface.h"
-#include "cmsis_os2.h"
 
 /**
  * \brief the ns_lock ID
  */
-static osMutexId_t ns_lock_handle = NULL;
+static void *ns_lock_handle = NULL;
 
 __attribute__((weak))
 int32_t tfm_ns_interface_dispatch(veneer_fn fn,
@@ -22,18 +23,16 @@ int32_t tfm_ns_interface_dispatch(veneer_fn fn,
                                   uint32_t arg2, uint32_t arg3)
 {
     int32_t result;
-    osStatus_t status;
 
     /* TFM request protected by NS lock */
-    status = osMutexAcquire(ns_lock_handle, osWaitForever);
-    if (status != osOK) {
+    if (os_wrapper_mutex_acquire(ns_lock_handle, OS_WRAPPER_WAIT_FOREVER)
+            != OS_WRAPPER_SUCCESS) {
         return (int32_t)TFM_ERROR_GENERIC;
     }
 
     result = fn(arg0, arg1, arg2, arg3);
 
-    status = osMutexRelease(ns_lock_handle);
-    if (status != osOK) {
+    if (os_wrapper_mutex_release(ns_lock_handle) != OS_WRAPPER_SUCCESS) {
         return (int32_t)TFM_ERROR_GENERIC;
     }
 
@@ -43,22 +42,13 @@ int32_t tfm_ns_interface_dispatch(veneer_fn fn,
 __attribute__((weak))
 enum tfm_status_e tfm_ns_interface_init(void)
 {
-    const osMutexAttr_t attr = {
-        .name = NULL,
-        .attr_bits = osMutexPrioInherit, /* Priority inheritance is recommended
-                                          * to enable if it is supported.
-                                          * For recursive mutex and the ability
-                                          * of auto release when owner being
-                                          * terminated is not required.
-                                          */
-        .cb_mem = NULL,
-        .cb_size = 0U
-    };
+    void *handle;
 
-    ns_lock_handle = osMutexNew(&attr);
-    if (!ns_lock_handle) {
+    handle = os_wrapper_mutex_create();
+    if (!handle) {
         return TFM_ERROR_GENERIC;
     }
 
+    ns_lock_handle = handle;
     return TFM_SUCCESS;
 }

--- a/platform/ext/target/cypress/psoc64/mailbox/platform_ns_mailbox.c
+++ b/platform/ext/target/cypress/psoc64/mailbox/platform_ns_mailbox.c
@@ -15,9 +15,9 @@
 #include "cy_sysint.h"
 
 #include "ns_ipc_config.h"
+#include "os_wrapper/thread.h"
 #include "tfm_ns_mailbox.h"
 #include "platform_multicore.h"
-#include "cmsis_os2.h"
 
 static uint8_t saved_irq_state = 1;
 
@@ -101,7 +101,7 @@ int32_t tfm_ns_mailbox_hal_init(struct ns_mailbox_queue_t *queue)
 const void *tfm_ns_mailbox_get_task_handle(void)
 {
 #ifdef TFM_MULTI_CORE_MULTI_CLIENT_CALL
-    return osThreadGetId();
+    return os_wrapper_thread_get_handle();
 #else
     return NULL;
 #endif
@@ -109,7 +109,7 @@ const void *tfm_ns_mailbox_get_task_handle(void)
 
 void tfm_ns_mailbox_hal_wait_reply(mailbox_msg_handle_t handle)
 {
-    osThreadFlagsWait(handle, osFlagsWaitAll, osWaitForever);
+    os_wrapper_thread_wait_flag((uint32_t)handle, OS_WRAPPER_WAIT_FOREVER);
 }
 
 void tfm_ns_mailbox_hal_enter_critical(void)
@@ -167,7 +167,7 @@ void cpuss_interrupts_ipc_8_IRQHandler(void)
 {
     uint32_t magic;
     mailbox_msg_handle_t handle;
-    osThreadId_t task_handle;
+    void *task_handle;
 
     if (!mailbox_clear_intr())
         return;
@@ -181,12 +181,9 @@ void cpuss_interrupts_ipc_8_IRQHandler(void)
                 break;
             }
 
-            task_handle = (osThreadId_t)tfm_ns_mailbox_get_msg_owner(handle);
+            task_handle = (void *)tfm_ns_mailbox_get_msg_owner(handle);
             if (task_handle) {
-                /* According to the description of CMSIS-RTOS v2 Thread Flags,
-                 * osThreadFlagsSet() can be called inside Interrupt Service
-                 * Routine. */
-                osThreadFlagsSet(task_handle, handle);
+                os_wrapper_thread_set_flag_isr(task_handle, (uint32_t)handle);
             }
         }
     }


### PR DESCRIPTION
The following PRs are related, we should coordinate to get them in roughly at the same time:
https://github.com/ARMmbed/trusted-firmware-m/pull/16
https://github.com/ARMmbed/tf-m-tests/pull/3
https://github.com/ARMmbed/mbed-os-tf-m-regression-tests/pull/93
https://github.com/ARMmbed/mbed-os/pull/14396

Previous, we patched TF-M to replace its OS wrapper with CMSIS RTOS to resolve manage management issue when integrated with Mbed OS. But as of TF-M v1.2, the OS wrapper has been reworked in the vanilla TF-M, and now it makes identical calls to its underlying CMSIS RTOS as our patches do. So, we remove our patches and use vanilla TF-M's OS wrapper instead to avoid extra maintenance overhead.